### PR TITLE
[feature]: (#15) add sub item group filter

### DIFF
--- a/frontend/src/components/Item/ItemFilters.vue
+++ b/frontend/src/components/Item/ItemFilters.vue
@@ -20,7 +20,17 @@
 			<Autocomplete
 				:options="this.item_group_options"
 				v-model="this.filters.item_group"
+				@update:model-value="updateItemSubGroups"
 				placeholder="Filter by Item Group"
+				variant="outline"
+			/>
+		</div>
+
+		<div class="w-full" v-if="sub_group_list > 0">
+			<Autocomplete
+				:options="filtered_sub_groups"
+				v-model="filters.item_sub_group"
+				placeholder="Filter by Item Sub Group"
 				variant="outline"
 			/>
 		</div>
@@ -71,15 +81,47 @@ export default {
 	data() {
 		return {
 			debounced_reset_filters: debounce(this.reset_filters, 150),
+			sub_group_list: 0,
+			filtered_sub_groups: []
 		}
 	},
-
+	mounted() {
+		// Initializing sub-groups if item_group is already set
+		if (this.filters.item_group) {
+			this.updateItemSubGroups(this.filters.item_group);
+		}
+	},
 	methods: {
 		reset_filters() {
 			for (let k of Object.keys(this.filters)) {
 				this.filters[k] = null;
 			}
+			this.sub_group_list = 0;
+			this.filtered_sub_groups = [];
 		},
+		updateItemSubGroups(item_group) {
+			if (!item_group) {
+				this.sub_group_list = 0;
+				this.filtered_sub_groups = [];
+				return;
+			}
+			const group_item = item_group.value || item_group;
+			const children = (active_item_groups.value || []).filter(
+				group => group.parent_item_group === group_item
+			);
+			
+			this.sub_group_list = children.length;
+			this.filtered_sub_groups = children.map(group => ({
+				label: group.name,
+				value: group.name,
+			}));
+
+			if (this.filters.item_sub_group.value && !this.filtered_sub_groups.some(
+				option => option.value === this.filters.item_sub_group.value
+			)) {
+				this.filters.item_sub_group = null;
+			}
+		}
 	},
 
 	computed: {

--- a/frontend/src/components/Item/ItemFilters.vue
+++ b/frontend/src/components/Item/ItemFilters.vue
@@ -102,10 +102,13 @@ export default {
 		},
 
 		item_sub_group_options() {
-			if (this.filters.item_group) {
-				let descendants = get_item_group_descendants(this.filters.item_group.value);
-				return this.item_group_options.filter(d => {
-					return descendants.includes(d.value);
+			if (this.filters.item_group?.value) {
+				let active_descendants = get_item_group_descendants(this.filters.item_group.value);
+				return active_descendants.map(d => {
+					return {
+						label: d,
+						value: d,
+					}
 				});
 			}
 

--- a/frontend/src/data/items.js
+++ b/frontend/src/data/items.js
@@ -99,18 +99,6 @@ export const in_item_group = (item_group_item, item_group_filter) => {
 	}
 }
 
-export const in_item_sub_group = (item, item_group, item_sub_group_filter) => {
-
-	if (!item.item_group || !item_sub_group_filter) {
-		return false;
-	}
-	
-	let ig_item = get_item_group(item_sub_group_filter);
-	// return the rows whose item group matches the sub group and the subgroups parent is the group selected
-	return item.item_group ==  item_sub_group_filter &&
-			ig_item.parent_item_group == item_group;
-}
-
 export const get_item_group = (item_group) => {
 	return (item_group_list.dataMap || {})[item_group];
 }
@@ -153,6 +141,22 @@ const get_item_group_ancestors = (item_group) => {
 	}
 
 	return ancestors;
+}
+
+export const get_item_group_descendants = (item_group) => {
+	let ig = get_item_group(item_group);
+
+	let descendants = [];
+	if (ig) {
+		descendants = (item_group_list.data || []).filter(d => {
+			return (
+				d.lft > ig.lft
+				&& d.rgt < ig.rgt
+			)
+		}).map(d => d.name);
+	}
+
+	return descendants;
 }
 
 // Brand Data

--- a/frontend/src/data/items.js
+++ b/frontend/src/data/items.js
@@ -99,6 +99,18 @@ export const in_item_group = (item_group_item, item_group_filter) => {
 	}
 }
 
+export const in_item_sub_group = (item, item_group, item_sub_group_filter) => {
+
+	if (!item.item_group || !item_sub_group_filter) {
+		return false;
+	}
+	
+	let ig_item = get_item_group(item_sub_group_filter);
+	// return the rows whose item group matches the sub group and the subgroups parent is the group selected
+	return item.item_group ==  item_sub_group_filter &&
+			ig_item.parent_item_group == item_group;
+}
+
 export const get_item_group = (item_group) => {
 	return (item_group_list.dataMap || {})[item_group];
 }

--- a/frontend/src/data/items.js
+++ b/frontend/src/data/items.js
@@ -143,12 +143,15 @@ const get_item_group_ancestors = (item_group) => {
 	return ancestors;
 }
 
-export const get_item_group_descendants = (item_group) => {
+export const get_item_group_descendants = (item_group, include_inactive=false) => {
 	let ig = get_item_group(item_group);
 
 	let descendants = [];
 	if (ig) {
-		descendants = (item_group_list.data || []).filter(d => {
+		let ig_list = include_inactive ? item_group_list.data : sorted_item_groups.value;
+		ig_list = ig_list || [];
+
+		descendants = ig_list.filter(d => {
 			return (
 				d.lft > ig.lft
 				&& d.rgt < ig.rgt

--- a/frontend/src/pages/MainPage/ItemListView.vue
+++ b/frontend/src/pages/MainPage/ItemListView.vue
@@ -38,7 +38,7 @@
 <script>
 import ItemGridList from "@/components/Item/ItemGridList.vue";
 import ItemFilters from "@/components/Item/ItemFilters.vue";
-import { item_list, active_items, in_item_group } from "@/data/items";
+import { item_list, active_items, in_item_group, in_item_sub_group} from "@/data/items";
 import FuzzySearch from "@/mixins/FuzzySearch";
 import {PackageSearch} from "lucide-vue-next";
 import GridListSelector from "@/components/GridList/GridListSelector.vue";
@@ -77,7 +77,8 @@ export default {
 			filters: {
 				txt: null,
 				item_group: null,
-				brand: null,
+				item_sub_group: null,
+				brand: null
 			},
 			item_list: item_list,
 			fuzzy_search_keys: ['item_name', 'name'],
@@ -86,8 +87,13 @@ export default {
 				"item-group": this.set_item_group_filter,
 				"brand": this.set_brand_filter,
 				"txt": "txt",
+				"item-sub-group": this.set_item_sub_group
 			}
 		}
+	},
+
+	created() {
+		this.parse_query_params();
 	},
 
 	computed: {
@@ -100,6 +106,10 @@ export default {
 
 			if (this.filters.item_group?.value) {
 				items = items.filter(d => in_item_group(d.item_group, this.filters.item_group.value));
+			}
+			
+			if (this.filters.item_sub_group?.value) {
+				items = items.filter(d => in_item_sub_group(d, this.filters.item_group.value, this.filters.item_sub_group.value));
 			}
 
 			return items;
@@ -168,6 +178,7 @@ export default {
 				query: {
 					'item-group': this.filters.item_group?.value || undefined,
 					'brand': this.filters.brand?.value || undefined,
+					'item-sub-group': this.filters.item_sub_group?.value || undefined
 				},
 			});
 		},
@@ -183,6 +194,14 @@ export default {
 				this.filters.item_group = { label: value, value: value };
 			} else {
 				this.filters.item_group = null;
+			}
+		},
+
+		set_item_sub_group(value) {
+			if (value) {
+				this.filters.item_sub_group = { label: value, value: value };
+			} else {
+				this.filters.item_sub_group = null;
 			}
 		},
 

--- a/frontend/src/pages/MainPage/ItemListView.vue
+++ b/frontend/src/pages/MainPage/ItemListView.vue
@@ -38,7 +38,7 @@
 <script>
 import ItemGridList from "@/components/Item/ItemGridList.vue";
 import ItemFilters from "@/components/Item/ItemFilters.vue";
-import { item_list, active_items, in_item_group } from "@/data/items";
+import {item_list, active_items, in_item_group, get_item_group_descendants} from "@/data/items";
 import FuzzySearch from "@/mixins/FuzzySearch";
 import {PackageSearch} from "lucide-vue-next";
 import GridListSelector from "@/components/GridList/GridListSelector.vue";
@@ -120,16 +120,29 @@ export default {
 		},
 
 		show_groups() {
-			let hide_groups = this.clean_txt || (this.filters.item_group && this.filters.brand);
+			let hide_groups = (
+				this.clean_txt
+				|| (this.filters.item_group && (this.filters.item_sub_group || !this.has_sub_item_groups) && this.filters.brand)
+			);
 			return !hide_groups;
 		},
 
 		group_field() {
-			if (this.filters.item_group) {
+			if (this.filters.item_group && (this.filters.item_sub_group || !this.has_sub_item_groups)) {
 				return "brand";
 			} else {
 				return "item_group";
 			}
+		},
+
+		has_sub_item_groups() {
+			if (this.filters.item_group?.value) {
+				let active_descendants = get_item_group_descendants(this.filters.item_group.value);
+				if (active_descendants.length) {
+					return true;
+				}
+			}
+			return false;
 		},
 
 		list_data() {

--- a/frontend/src/pages/MainPage/ItemListView.vue
+++ b/frontend/src/pages/MainPage/ItemListView.vue
@@ -38,7 +38,7 @@
 <script>
 import ItemGridList from "@/components/Item/ItemGridList.vue";
 import ItemFilters from "@/components/Item/ItemFilters.vue";
-import { item_list, active_items, in_item_group, in_item_sub_group} from "@/data/items";
+import { item_list, active_items, in_item_group } from "@/data/items";
 import FuzzySearch from "@/mixins/FuzzySearch";
 import {PackageSearch} from "lucide-vue-next";
 import GridListSelector from "@/components/GridList/GridListSelector.vue";
@@ -78,7 +78,7 @@ export default {
 				txt: null,
 				item_group: null,
 				item_sub_group: null,
-				brand: null
+				brand: null,
 			},
 			item_list: item_list,
 			fuzzy_search_keys: ['item_name', 'name'],
@@ -87,13 +87,9 @@ export default {
 				"item-group": this.set_item_group_filter,
 				"brand": this.set_brand_filter,
 				"txt": "txt",
-				"item-sub-group": this.set_item_sub_group
+				"sub-group": this.set_item_sub_group,
 			}
 		}
-	},
-
-	created() {
-		this.parse_query_params();
 	},
 
 	computed: {
@@ -107,9 +103,9 @@ export default {
 			if (this.filters.item_group?.value) {
 				items = items.filter(d => in_item_group(d.item_group, this.filters.item_group.value));
 			}
-			
+
 			if (this.filters.item_sub_group?.value) {
-				items = items.filter(d => in_item_sub_group(d, this.filters.item_group.value, this.filters.item_sub_group.value));
+				items = items.filter(d => in_item_group(d.item_group, this.filters.item_sub_group.value));
 			}
 
 			return items;
@@ -178,7 +174,7 @@ export default {
 				query: {
 					'item-group': this.filters.item_group?.value || undefined,
 					'brand': this.filters.brand?.value || undefined,
-					'item-sub-group': this.filters.item_sub_group?.value || undefined
+					'sub-group': this.filters.item_sub_group?.value || undefined
 				},
 			});
 		},


### PR DESCRIPTION
Dev Notes:

- Added a new sub item group filter in the Item List Section of Sales Portal.
- Users can select groups from the list, and if the group has sub groups a new filter will be rendered for users to select.
- This filters out the combination of group and subgroups and displays the results to users.


Closes [](https://github.com/ParaLogicTech/portal/issues/15)